### PR TITLE
Add --detach flag to zmx attach to create a session without attaching

### DIFF
--- a/src/completions.zig
+++ b/src/completions.zig
@@ -38,18 +38,6 @@ const bash_completions =
     \\    return 0
     \\  fi
     \\
-    \\  if [[ "$cur" == -* ]]; then
-    \\    local flags="-g --group"
-    \\    for word in "${COMP_WORDS[@]}"; do
-    \\      if [[ "$word" == "attach" || "$word" == "a" ]]; then
-    \\        flags="$flags --detach"
-    \\        break
-    \\      fi
-    \\    done
-    \\    COMPREPLY=($(compgen -W "$flags" -- "$cur"))
-    \\    return 0
-    \\  fi
-    \\
     \\  # Find the subcommand (skip -g <group>)
     \\  local subcmd=""
     \\  local i=1
@@ -65,6 +53,15 @@ const bash_completions =
     \\    fi
     \\    ((i++))
     \\  done
+    \\
+    \\  if [[ "$cur" == -* ]]; then
+    \\    local flags="-g --group"
+    \\    if [[ "$subcmd" == "attach" || "$subcmd" == "a" ]]; then
+    \\      flags="$flags --detach"
+    \\    fi
+    \\    COMPREPLY=($(compgen -W "$flags" -- "$cur"))
+    \\    return 0
+    \\  fi
     \\
     \\  if [[ -z "$subcmd" ]]; then
     \\    COMPREPLY=($(compgen -W "$commands" -- "$cur"))

--- a/src/completions.zig
+++ b/src/completions.zig
@@ -39,7 +39,14 @@ const bash_completions =
     \\  fi
     \\
     \\  if [[ "$cur" == -* ]]; then
-    \\    COMPREPLY=($(compgen -W "-g --group" -- "$cur"))
+    \\    local flags="-g --group"
+    \\    for word in "${COMP_WORDS[@]}"; do
+    \\      if [[ "$word" == "attach" || "$word" == "a" ]]; then
+    \\        flags="$flags --detach"
+    \\        break
+    \\      fi
+    \\    done
+    \\    COMPREPLY=($(compgen -W "$flags" -- "$cur"))
     \\    return 0
     \\  fi
     \\
@@ -116,7 +123,14 @@ const zsh_completions =
     \\      ;;
     \\    args)
     \\      case $words[2] in
-    \\        attach|a|detach|d|kill|k|run|r|history|hi)
+    \\        attach|a)
+    \\          if [[ $words[CURRENT] == -* ]]; then
+    \\            _values 'options' '--detach[Create session without attaching]'
+    \\          else
+    \\            _zmx_sessions
+    \\          fi
+    \\          ;;
+    \\        detach|d|kill|k|run|r|history|hi)
     \\          _zmx_sessions
     \\          ;;
     \\        completions|c)
@@ -178,6 +192,8 @@ const fish_completions =
     \\complete -c zmx -n $no_subcmd -a help -d 'Show help message'
     \\
     \\complete -c zmx -n "__fish_seen_subcommand_from attach run detach kill history" -a '(zmx list --short 2>/dev/null)' -d 'Session name'
+    \\
+    \\complete -c zmx -n "__fish_seen_subcommand_from attach a" -l detach -d 'Create session without attaching'
     \\
     \\complete -c zmx -n "__fish_seen_subcommand_from completions" -a 'bash zsh fish' -d 'Shell'
     \\

--- a/src/main.zig
+++ b/src/main.zig
@@ -467,15 +467,22 @@ pub fn main() !void {
         }
         return history(&cfg, session_name.?, format);
     } else if (std.mem.eql(u8, command, "attach") or std.mem.eql(u8, command, "a")) {
-        const session_name = args.next() orelse {
-            return error.SessionNameRequired;
-        };
-
+        var detach_flag = false;
+        var session_name: ?[]const u8 = null;
+        var command_started = false;
         var command_args: std.ArrayList([]const u8) = .empty;
         defer command_args.deinit(alloc);
         while (args.next()) |arg| {
-            try command_args.append(alloc, arg);
+            if (!command_started and std.mem.eql(u8, arg, "--detach")) {
+                detach_flag = true;
+            } else if (!command_started and session_name == null) {
+                session_name = arg;
+            } else {
+                command_started = true;
+                try command_args.append(alloc, arg);
+            }
         }
+        const name = session_name orelse return error.SessionNameRequired;
 
         const clients = try std.ArrayList(*Client).initCapacity(alloc, 10);
         var spawn_command: ?[][]const u8 = null;
@@ -491,15 +498,15 @@ pub fn main() !void {
             .cfg = &cfg,
             .alloc = alloc,
             .clients = clients,
-            .session_name = session_name,
+            .session_name = name,
             .socket_path = undefined,
             .pid = undefined,
             .command = spawn_command,
             .cwd = cwd,
         };
-        daemon.socket_path = try getSocketPath(alloc, cfg.socket_dir, session_name);
+        daemon.socket_path = try getSocketPath(alloc, cfg.socket_dir, name);
         std.log.info("socket path={s}", .{daemon.socket_path});
-        return attach(&daemon);
+        return attach(&daemon, detach_flag);
     } else if (std.mem.eql(u8, command, "run") or std.mem.eql(u8, command, "r")) {
         const session_name = args.next() orelse {
             return error.SessionNameRequired;
@@ -566,7 +573,9 @@ fn help() !void {
         \\  -g, --group <name>            Session group (default: "default", or $ZMX_GROUP)
         \\
         \\Commands:
-        \\  [a]ttach <name> [command...]  Attach to session, creating session if needed
+        \\  [a]ttach <name> [command...] [--detach]
+        \\                                Attach to session, creating session if needed
+        \\                                (--detach: create session without attaching)
         \\  [f]ork [<name>]               Fork current session (same cmd + cwd) into a new session
         \\  [r]un <name> [command...]     Send command without attaching, creating session if needed
         \\  [d]etach [<name>]              Detach all clients from current or named session
@@ -1156,13 +1165,25 @@ fn ensureSession(daemon: *Daemon) !EnsureSessionResult {
     return .{ .created = false, .is_daemon = false };
 }
 
-fn attach(daemon: *Daemon) !void {
-    if (std.posix.getenv("ZMX_SESSION")) |_| {
-        return error.CannotAttachToSessionInSession;
+fn attach(daemon: *Daemon, detach: bool) !void {
+    if (!detach) {
+        if (std.posix.getenv("ZMX_SESSION")) |_| {
+            return error.CannotAttachToSessionInSession;
+        }
     }
 
     const result = try ensureSession(daemon);
     if (result.is_daemon) return;
+
+    if (detach) {
+        if (result.created) {
+            var buf: [4096]u8 = undefined;
+            var w = std.fs.File.stdout().writer(&buf);
+            try w.interface.print("session \"{s}\" created\n", .{daemon.session_name});
+            try w.interface.flush();
+        }
+        return;
+    }
 
     const client_sock = try sessionConnect(daemon.socket_path);
     std.log.info("attached session={s}", .{daemon.session_name});

--- a/src/main.zig
+++ b/src/main.zig
@@ -573,7 +573,8 @@ fn help() !void {
         \\Commands:
         \\  [a]ttach <name> [command...] [--detach]
         \\                                Attach to session, creating session if needed
-        \\                                (--detach: create session without attaching)
+        \\                                (--detach: ensure session exists, print status, and exit
+        \\                                without attaching; flag is accepted in any position)
         \\  [f]ork [<name>]               Fork current session (same cmd + cwd) into a new session
         \\  [r]un <name> [command...]     Send command without attaching, creating session if needed
         \\  [d]etach [<name>]              Detach all clients from current or named session

--- a/src/main.zig
+++ b/src/main.zig
@@ -469,16 +469,14 @@ pub fn main() !void {
     } else if (std.mem.eql(u8, command, "attach") or std.mem.eql(u8, command, "a")) {
         var detach_flag = false;
         var session_name: ?[]const u8 = null;
-        var command_started = false;
         var command_args: std.ArrayList([]const u8) = .empty;
         defer command_args.deinit(alloc);
         while (args.next()) |arg| {
-            if (!command_started and std.mem.eql(u8, arg, "--detach")) {
+            if (std.mem.eql(u8, arg, "--detach")) {
                 detach_flag = true;
-            } else if (!command_started and session_name == null) {
+            } else if (session_name == null) {
                 session_name = arg;
             } else {
-                command_started = true;
                 try command_args.append(alloc, arg);
             }
         }
@@ -1176,12 +1174,14 @@ fn attach(daemon: *Daemon, detach: bool) !void {
     if (result.is_daemon) return;
 
     if (detach) {
+        var buf: [4096]u8 = undefined;
+        var w = std.fs.File.stdout().writer(&buf);
         if (result.created) {
-            var buf: [4096]u8 = undefined;
-            var w = std.fs.File.stdout().writer(&buf);
             try w.interface.print("session \"{s}\" created\n", .{daemon.session_name});
-            try w.interface.flush();
+        } else {
+            try w.interface.print("session \"{s}\" already exists\n", .{daemon.session_name});
         }
+        try w.interface.flush();
         return;
     }
 


### PR DESCRIPTION
`zmx attach <name> --detach` creates the session (if missing) and exits
immediately, without taking over the calling terminal. The flag is
accepted in any position before the spawn command. Works with or
without a spawn command, and is allowed from inside an existing zmx
session (the ZMX_SESSION nesting check is skipped since we don't
attach).

Also updates bash/zsh/fish completion scripts and the `help` output.